### PR TITLE
Validity check for aggregate_from_subdistricts

### DIFF
--- a/tests/test_common_aggregate_dfs.py
+++ b/tests/test_common_aggregate_dfs.py
@@ -99,6 +99,17 @@ class Tester(unittest.TestCase):
             else:
                 self.assertListEqual(list(df_act[col]), list(df_exp[col]))
 
+    def test_aggregate_from_subdistricts_2(self):
+
+        aggregations = [{'agg_func': 'sum',
+                         'data_points': ['inhabitants']},
+                        {'agg_func': 'wmean',
+                         'data_points': 'mean_income',
+                         'data_weights': 'inhabitants'}]
+
+        with self.assertRaises(ValueError):
+            aggregate_dfs.aggregate_from_subdistricts(df_org, aggregations)
+
     def test_merge_df(self):
 
         df1 = df_org[['date', 'district', 'delbydelid', 'mean_income']].copy()


### PR DESCRIPTION
Adding an additional argument validity check and improved explanation to the aggregate_from_subdistricts function.

Øyvind - this addresses the ambiguity you pointed out. I have not changed the key name, since this would affect other files already using this function, but added a check which would highlight and explain incorrect use of the arguments.