### PR TITLE
Include geography name in output if passed in

### DIFF
--- a/common/transform_output.py
+++ b/common/transform_output.py
@@ -240,16 +240,19 @@ def df_to_template_a(
 
 
 def df_to_template_b(
-    geography, df, data_points, avg_row=False, total_row=False, link_to=False
+    geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False, link_to=False
 ):
     if len(data_points) > 1:
         raise Exception("Template B only takes one datapoint")
     obj_b = {
-        "geography": geography,
+        "geography": geography_name or geography_id,
         "avgRow": avg_row,
         "totalRow": total_row,
         "values": [],
     }
+    if geography_name:
+        obj_b["id"] = geography_id
+
     value_list = []
     data_point = data_points[0]
     for values in df.to_dict("r"):
@@ -282,14 +285,17 @@ def df_to_template_c(
     return obj_c
 
 
-def df_to_template_i(geography, df, data_points, avg_row=False, total_row=False):
+def df_to_template_i(geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False):
 
     obj_i = {
-        "geography": geography,
+        "geography": geography_name or geography_id,
         "values": [],
         "avgRow": avg_row,
         "totalRow": total_row,
     }
+    if geography_name:
+        obj_i["id"] = geography_id
+
     series = {}
     for values in df.to_dict("r"):
         for data_point in data_points:
@@ -299,14 +305,16 @@ def df_to_template_i(geography, df, data_points, avg_row=False, total_row=False)
     return obj_i
 
 
-def df_to_template_j(geography, df, data_points, avg_row=False, total_row=False):
+def df_to_template_j(geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False):
 
     obj_j = {
-        "geography": geography,
+        "geography": geography_name or geography_id,
         "values": [],
         "avgRow": avg_row,
         "totalRow": total_row,
     }
+    if geography_name:
+        obj_j["id"] = geography_id
 
     data_row = df.to_dict("records")[
         0

--- a/common/transform_output.py
+++ b/common/transform_output.py
@@ -240,7 +240,13 @@ def df_to_template_a(
 
 
 def df_to_template_b(
-    geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False, link_to=False
+    geography_id,
+    df,
+    data_points,
+    geography_name=None,
+    avg_row=False,
+    total_row=False,
+    link_to=False,
 ):
     if len(data_points) > 1:
         raise Exception("Template B only takes one datapoint")
@@ -285,7 +291,9 @@ def df_to_template_c(
     return obj_c
 
 
-def df_to_template_i(geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False):
+def df_to_template_i(
+    geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False
+):
 
     obj_i = {
         "geography": geography_name or geography_id,
@@ -305,7 +313,9 @@ def df_to_template_i(geography_id, df, data_points, geography_name=None, avg_row
     return obj_i
 
 
-def df_to_template_j(geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False):
+def df_to_template_j(
+    geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False
+):
 
     obj_j = {
         "geography": geography_name or geography_id,

--- a/common/transform_output.py
+++ b/common/transform_output.py
@@ -178,37 +178,26 @@ def df_to_template(
     total_row=False,
 ):
     if template.lower() == "a":
-        return df_to_template_a(
-            geography_id,
-            df,
-            data_points,
-            geography_name=geography_name,
-            avg_row=avg_row,
-            total_row=total_row,
-        )
+        template_fun = df_to_template_a
     elif template.lower() == "b":
-        return df_to_template_b(
-            geography_id, df, data_points, avg_row=avg_row, total_row=total_row
-        )
+        template_fun = df_to_template_b
     elif template.lower() == "c":
-        return df_to_template_c(
-            geography_id,
-            df,
-            data_points,
-            geography_name=geography_name,
-            avg_row=avg_row,
-            total_row=total_row,
-        )
+        template_fun = df_to_template_c
     elif template.lower() == "i":
-        return df_to_template_i(
-            geography_id, df, data_points, avg_row=avg_row, total_row=total_row
-        )
+        template_fun = df_to_template_i
     elif template.lower() == "j":
-        return df_to_template_j(
-            geography_id, df, data_points, avg_row=avg_row, total_row=total_row
-        )
+        template_fun = df_to_template_j
     else:
         raise Exception(f"Template {template} does not exist")
+
+    return template_fun(
+        geography_id,
+        df,
+        data_points,
+        geography_name=geography_name,
+        avg_row=avg_row,
+        total_row=total_row,
+    )
 
 
 def df_to_template_a(

--- a/common/transform_output.py
+++ b/common/transform_output.py
@@ -32,39 +32,78 @@ def generate_output_list(df, template, data_points):
         district_name_all = "Oslo i alt"
 
     district_list = [
-        (x.district, x.bydel_navn) for x in set(df.loc[:, ["district", "bydel_navn"]].itertuples(index=False))
+        (x.district, x.bydel_navn)
+        for x in set(df.loc[:, ["district", "bydel_navn"]].itertuples(index=False))
         if x.district not in ["00", "16", "17", "99"]
     ]
     district_list.sort()
 
     output_list = []
-    oslo_total = [district_time_series(df, "00", template, data_points, district_name=district_name_all, total_row=True)]
+    oslo_total = [
+        district_time_series(
+            df,
+            "00",
+            template,
+            data_points,
+            district_name=district_name_all,
+            total_row=True,
+        )
+    ]
     for (district_id, district_name) in district_list:
         obj = {
             "district": district_name or district_id,
             "template": template,
-            "data": district_time_series_list(df, district_id, template, data_points, district_name=district_name),
+            "data": district_time_series_list(
+                df, district_id, template, data_points, district_name=district_name
+            ),
         }
         if district_name:
             obj["id"] = district_id
 
         output_list.append(obj)
-        oslo_total.append(district_time_series(df, district_id, template, data_points, district_name=district_name))
+        oslo_total.append(
+            district_time_series(
+                df, district_id, template, data_points, district_name=district_name
+            )
+        )
 
     if district_name_all:
-        output_list.append({"id": "00", "district": "Oslo i alt", "template": template, "data": oslo_total})
+        output_list.append(
+            {
+                "id": "00",
+                "district": "Oslo i alt",
+                "template": template,
+                "data": oslo_total,
+            }
+        )
     else:
         output_list.append({"district": "00", "template": template, "data": oslo_total})
 
     return output_list
 
 
-def district_time_series_list(df, district_id, template, data_points, district_name=None):
+def district_time_series_list(
+    df, district_id, template, data_points, district_name=None
+):
     district_name_all = "Oslo i alt" if district_name else None
 
     time_series = [
-        district_time_series(df, "00", template, data_points, district_name=district_name_all, total_row=True),
-        district_time_series(df, district_id, template, data_points, district_name=district_name, avg_row=True),
+        district_time_series(
+            df,
+            "00",
+            template,
+            data_points,
+            district_name=district_name_all,
+            total_row=True,
+        ),
+        district_time_series(
+            df,
+            district_id,
+            template,
+            data_points,
+            district_name=district_name,
+            avg_row=True,
+        ),
     ]
 
     district_df = df[df["district"] == district_id]
@@ -75,18 +114,33 @@ def district_time_series_list(df, district_id, template, data_points, district_n
     sub_districts_df = sub_districts_df[["delbydelid", "delbydel_navn"]]
 
     sub_districts = [
-        (x.delbydelid, x.delbydel_navn) for x in set(sub_districts_df.itertuples(index=False))
+        (x.delbydelid, x.delbydel_navn)
+        for x in set(sub_districts_df.itertuples(index=False))
     ]
     sub_districts.sort()
 
     for (sub_district_id, sub_district_name) in sub_districts:
-        time_series.append(sub_district_time_series(district_df, sub_district_id, template, data_points, sub_district_name=sub_district_name))
+        time_series.append(
+            sub_district_time_series(
+                district_df,
+                sub_district_id,
+                template,
+                data_points,
+                sub_district_name=sub_district_name,
+            )
+        )
 
     return time_series
 
 
 def district_time_series(
-    df, district_id, template, data_points, district_name=None, avg_row=False, total_row=False
+    df,
+    district_id,
+    template,
+    data_points,
+    district_name=None,
+    avg_row=False,
+    total_row=False,
 ):
     district_df = df[df["district"] == district_id]
     district_df = district_df[district_df["delbydelid"].isnull()]
@@ -101,17 +155,36 @@ def district_time_series(
     )
 
 
-def sub_district_time_series(district_df, sub_district_id, template, data_points, sub_district_name=None):
+def sub_district_time_series(
+    district_df, sub_district_id, template, data_points, sub_district_name=None
+):
     sub_district_df = district_df[district_df["delbydelid"] == sub_district_id]
-    return df_to_template(sub_district_id, sub_district_df, template, data_points, geography_name=sub_district_name)
+    return df_to_template(
+        sub_district_id,
+        sub_district_df,
+        template,
+        data_points,
+        geography_name=sub_district_name,
+    )
 
 
 def df_to_template(
-    geography_id, df, template, data_points, geography_name=None, avg_row=False, total_row=False
+    geography_id,
+    df,
+    template,
+    data_points,
+    geography_name=None,
+    avg_row=False,
+    total_row=False,
 ):
     if template.lower() == "a":
         return df_to_template_a(
-            geography_id, df, data_points, geography_name=geography_name, avg_row=avg_row, total_row=total_row
+            geography_id,
+            df,
+            data_points,
+            geography_name=geography_name,
+            avg_row=avg_row,
+            total_row=total_row,
         )
     elif template.lower() == "b":
         return df_to_template_b(
@@ -119,7 +192,12 @@ def df_to_template(
         )
     elif template.lower() == "c":
         return df_to_template_c(
-            geography_id, df, data_points, geography_name=geography_name, avg_row=avg_row, total_row=total_row
+            geography_id,
+            df,
+            data_points,
+            geography_name=geography_name,
+            avg_row=avg_row,
+            total_row=total_row,
         )
     elif template.lower() == "i":
         return df_to_template_i(
@@ -134,7 +212,13 @@ def df_to_template(
 
 
 def df_to_template_a(
-    geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False, link_to=False
+    geography_id,
+    df,
+    data_points,
+    geography_name=None,
+    avg_row=False,
+    total_row=False,
+    link_to=False,
 ):
 
     obj_a = {
@@ -174,7 +258,9 @@ def df_to_template_b(
     return obj_b
 
 
-def df_to_template_c(geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False):
+def df_to_template_c(
+    geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False
+):
 
     obj_c = {
         "geography": geography_name or geography_id,

--- a/common/transform_output.py
+++ b/common/transform_output.py
@@ -10,6 +10,11 @@ generate_output_list:
         date: year
         data_point1- n: One column for each data_point
 
+        The user can optionally pass in 'bydel_navn' and 'delbydel_navn'
+        columns and have these be used to populate the 'geography' fields.
+        The 'delbydelid' and 'district' columns will then instead be used
+        to populate a new 'id' field in the output.
+
     * template: template to be used for generating output json
         valid values: 'a', 'c', 'i' so far...
 
@@ -20,100 +25,128 @@ generate_output_list:
 
 
 def generate_output_list(df, template, data_points):
+    if "bydel_navn" not in df:
+        df["bydel_navn"] = None
+        district_name_all = None
+    else:
+        district_name_all = "Oslo i alt"
+
     district_list = [
-        x for x in df["district"].unique() if x not in ["00", "16", "17", "99"]
+        (x.district, x.bydel_navn) for x in set(df.loc[:, ["district", "bydel_navn"]].itertuples(index=False))
+        if x.district not in ["00", "16", "17", "99"]
     ]
+    district_list.sort()
+
     output_list = []
-    oslo_total = [district_time_series(df, "00", template, data_points, total_row=True)]
-    for district in district_list:
-        output_list.append(
-            {
-                "district": district,
-                "template": template,
-                "data": district_time_series_list(df, district, template, data_points),
-            }
-        )
-        oslo_total.append(district_time_series(df, district, template, data_points))
-    output_list.append({"district": "00", "template": template, "data": oslo_total})
+    oslo_total = [district_time_series(df, "00", template, data_points, district_name=district_name_all, total_row=True)]
+    for (district_id, district_name) in district_list:
+        obj = {
+            "district": district_name or district_id,
+            "template": template,
+            "data": district_time_series_list(df, district_id, template, data_points, district_name=district_name),
+        }
+        if district_name:
+            obj["id"] = district_id
+
+        output_list.append(obj)
+        oslo_total.append(district_time_series(df, district_id, template, data_points, district_name=district_name))
+
+    if district_name_all:
+        output_list.append({"id": "00", "district": "Oslo i alt", "template": template, "data": oslo_total})
+    else:
+        output_list.append({"district": "00", "template": template, "data": oslo_total})
 
     return output_list
 
 
-def district_time_series_list(df, district, template, data_points):
+def district_time_series_list(df, district_id, template, data_points, district_name=None):
+    district_name_all = "Oslo i alt" if district_name else None
+
     time_series = [
-        district_time_series(df, "00", template, data_points, total_row=True),
-        district_time_series(df, district, template, data_points, avg_row=True),
+        district_time_series(df, "00", template, data_points, district_name=district_name_all, total_row=True),
+        district_time_series(df, district_id, template, data_points, district_name=district_name, avg_row=True),
     ]
 
-    district_df = df[df["district"] == district]
-    sub_districts = district_df[district_df["delbydelid"].notnull()][
-        "delbydelid"
-    ].unique()
-    for sub_district in sub_districts:
-        time_series.append(
-            sub_district_time_series(district_df, sub_district, template, data_points)
-        )
+    district_df = df[df["district"] == district_id]
+
+    sub_districts_df = district_df[district_df["delbydelid"].notnull()]
+    if "delbydel_navn" not in sub_districts_df:
+        sub_districts_df["delbydel_navn"] = None
+    sub_districts_df = sub_districts_df[["delbydelid", "delbydel_navn"]]
+
+    sub_districts = [
+        (x.delbydelid, x.delbydel_navn) for x in set(sub_districts_df.itertuples(index=False))
+    ]
+    sub_districts.sort()
+
+    for (sub_district_id, sub_district_name) in sub_districts:
+        time_series.append(sub_district_time_series(district_df, sub_district_id, template, data_points, sub_district_name=sub_district_name))
+
     return time_series
 
 
 def district_time_series(
-    df, district, template, data_points, avg_row=False, total_row=False
+    df, district_id, template, data_points, district_name=None, avg_row=False, total_row=False
 ):
-    district_df = df[df["district"] == district]
+    district_df = df[df["district"] == district_id]
     district_df = district_df[district_df["delbydelid"].isnull()]
     return df_to_template(
-        district,
+        district_id,
         district_df,
         template,
         data_points,
+        geography_name=district_name,
         avg_row=avg_row,
         total_row=total_row,
     )
 
 
-def sub_district_time_series(district_df, sub_district, template, data_points):
-    sub_district_df = district_df[district_df["delbydelid"] == sub_district]
-    return df_to_template(sub_district, sub_district_df, template, data_points)
+def sub_district_time_series(district_df, sub_district_id, template, data_points, sub_district_name=None):
+    sub_district_df = district_df[district_df["delbydelid"] == sub_district_id]
+    return df_to_template(sub_district_id, sub_district_df, template, data_points, geography_name=sub_district_name)
 
 
 def df_to_template(
-    geography, df, template, data_points, avg_row=False, total_row=False
+    geography_id, df, template, data_points, geography_name=None, avg_row=False, total_row=False
 ):
     if template.lower() == "a":
         return df_to_template_a(
-            geography, df, data_points, avg_row=avg_row, total_row=total_row
+            geography_id, df, data_points, geography_name=geography_name, avg_row=avg_row, total_row=total_row
         )
     elif template.lower() == "b":
         return df_to_template_b(
-            geography, df, data_points, avg_row=avg_row, total_row=total_row
+            geography_id, df, data_points, avg_row=avg_row, total_row=total_row
         )
     elif template.lower() == "c":
         return df_to_template_c(
-            geography, df, data_points, avg_row=avg_row, total_row=total_row
+            geography_id, df, data_points, geography_name=geography_name, avg_row=avg_row, total_row=total_row
         )
     elif template.lower() == "i":
         return df_to_template_i(
-            geography, df, data_points, avg_row=avg_row, total_row=total_row
+            geography_id, df, data_points, avg_row=avg_row, total_row=total_row
         )
     elif template.lower() == "j":
         return df_to_template_j(
-            geography, df, data_points, avg_row=avg_row, total_row=total_row
+            geography_id, df, data_points, avg_row=avg_row, total_row=total_row
         )
     else:
         raise Exception(f"Template {template} does not exist")
 
 
 def df_to_template_a(
-    geography, df, data_points, avg_row=False, total_row=False, link_to=False
+    geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False, link_to=False
 ):
 
     obj_a = {
+        "geography": geography_name or geography_id,
         "linkTo": link_to,
-        "geography": geography,
         "avgRow": avg_row,
         "totalRow": total_row,
         "values": [],
     }
+    if geography_name:
+        obj_a["id"] = geography_id
+
     series = {}
     for values in df.to_dict("r"):
         for data_point in data_points:
@@ -141,14 +174,17 @@ def df_to_template_b(
     return obj_b
 
 
-def df_to_template_c(geography, df, data_points, avg_row=False, total_row=False):
+def df_to_template_c(geography_id, df, data_points, geography_name=None, avg_row=False, total_row=False):
 
     obj_c = {
-        "geography": geography,
+        "geography": geography_name or geography_id,
         "values": [],
         "avgRow": avg_row,
         "totalRow": total_row,
     }
+    if geography_name:
+        obj_c["id"] = geography_id
+
     time_series = list_to_time_series(data_points)
     for values in df.to_dict("r"):
         [

--- a/common/transform_output.py
+++ b/common/transform_output.py
@@ -144,10 +144,9 @@ def district_time_series(
 ):
     district_df = df[df["district"] == district_id]
     district_df = district_df[district_df["delbydelid"].isnull()]
-    return df_to_template(
+    return template_fun(template)(
         district_id,
         district_df,
-        template,
         data_points,
         geography_name=district_name,
         avg_row=avg_row,
@@ -159,45 +158,24 @@ def sub_district_time_series(
     district_df, sub_district_id, template, data_points, sub_district_name=None
 ):
     sub_district_df = district_df[district_df["delbydelid"] == sub_district_id]
-    return df_to_template(
-        sub_district_id,
-        sub_district_df,
-        template,
-        data_points,
-        geography_name=sub_district_name,
+    return template_fun(template)(
+        sub_district_id, sub_district_df, data_points, geography_name=sub_district_name
     )
 
 
-def df_to_template(
-    geography_id,
-    df,
-    template,
-    data_points,
-    geography_name=None,
-    avg_row=False,
-    total_row=False,
-):
+def template_fun(template):
     if template.lower() == "a":
-        template_fun = df_to_template_a
+        return df_to_template_a
     elif template.lower() == "b":
-        template_fun = df_to_template_b
+        return df_to_template_b
     elif template.lower() == "c":
-        template_fun = df_to_template_c
+        return df_to_template_c
     elif template.lower() == "i":
-        template_fun = df_to_template_i
+        return df_to_template_i
     elif template.lower() == "j":
-        template_fun = df_to_template_j
+        return df_to_template_j
     else:
         raise Exception(f"Template {template} does not exist")
-
-    return template_fun(
-        geography_id,
-        df,
-        data_points,
-        geography_name=geography_name,
-        avg_row=avg_row,
-        total_row=total_row,
-    )
 
 
 def df_to_template_a(

--- a/common/transform_output.py
+++ b/common/transform_output.py
@@ -144,7 +144,7 @@ def district_time_series(
 ):
     district_df = df[df["district"] == district_id]
     district_df = district_df[district_df["delbydelid"].isnull()]
-    return template_fun(template)(
+    return template_funs[template.lower()](
         district_id,
         district_df,
         data_points,
@@ -158,24 +158,9 @@ def sub_district_time_series(
     district_df, sub_district_id, template, data_points, sub_district_name=None
 ):
     sub_district_df = district_df[district_df["delbydelid"] == sub_district_id]
-    return template_fun(template)(
+    return template_funs[template.lower()](
         sub_district_id, sub_district_df, data_points, geography_name=sub_district_name
     )
-
-
-def template_fun(template):
-    if template.lower() == "a":
-        return df_to_template_a
-    elif template.lower() == "b":
-        return df_to_template_b
-    elif template.lower() == "c":
-        return df_to_template_c
-    elif template.lower() == "i":
-        return df_to_template_i
-    elif template.lower() == "j":
-        return df_to_template_j
-    else:
-        raise Exception(f"Template {template} does not exist")
 
 
 def df_to_template_a(
@@ -308,6 +293,15 @@ def df_to_template_j(
     obj_j["values"] = values
 
     return obj_j
+
+
+template_funs = {
+    "a": df_to_template_a,
+    "b": df_to_template_b,
+    "c": df_to_template_c,
+    "i": df_to_template_i,
+    "j": df_to_template_j,
+}
 
 
 def list_to_time_series(data_points):

--- a/tests/transform_output_test.py
+++ b/tests/transform_output_test.py
@@ -87,6 +87,15 @@ class Tester(unittest.TestCase):
         }
         self.assertDictEqual(output, expected)
 
+    def test_df_to_template_b_with_geography_name(self):
+        geography_id = "0301010101"
+        geography_name = "Subdistrict"
+        input_df = test_df[test_df["delbydelid"] == geography_id]
+        data_points = ["d1"]
+        output = transform.df_to_template_b(geography_id, input_df, data_points, geography_name=geography_name)
+        self.assertEqual(output["id"], geography_id)
+        self.assertEqual(output["geography"], geography_name)
+
     def test_df_to_template_b_error(self):
         geography = "0301010101"
         input_df = test_df[test_df["delbydelid"] == geography]
@@ -132,6 +141,15 @@ class Tester(unittest.TestCase):
         }
         self.assertDictEqual(output, expected)
 
+    def test_df_to_template_c_with_geography_name(self):
+        geography_id = "0301010101"
+        geography_name = "Subdistrict"
+        input_df = test_df[test_df["delbydelid"] == geography_id]
+        data_points = ["d1", "d2"]
+        output = transform.df_to_template_c(geography_id, input_df, data_points, geography_name=geography_name)
+        self.assertEqual(output["id"], geography_id)
+        self.assertEqual(output["geography"], geography_name)
+
     def test_df_to_template_i(self):
         geography = "0301010101"
         input_df = test_df_latest[test_df_latest["delbydelid"] == geography]
@@ -148,6 +166,15 @@ class Tester(unittest.TestCase):
         }
         self.assertDictEqual(output, expected)
 
+    def test_df_to_template_i(self):
+        geography_id = "0301010101"
+        geography_name = "Subdistrict"
+        input_df = test_df_latest[test_df_latest["delbydelid"] == geography_id]
+        data_points = ["d1", "d2"]
+        output = transform.df_to_template_i(geography_id, input_df, data_points, geography_name=geography_name)
+        self.assertEqual(output["id"], geography_id)
+        self.assertEqual(output["geography"], geography_name)
+
     def test_df_to_template_j(self):
         geography = "0301010101"
         input_df = test_df_latest[test_df_latest["delbydelid"] == geography]
@@ -163,6 +190,15 @@ class Tester(unittest.TestCase):
             ],
         }
         self.assertDictEqual(output, expected)
+
+    def test_df_to_template_j_with_geography_name(self):
+        geography_id = "0301010101"
+        geography_name = "0301010101"
+        input_df = test_df_latest[test_df_latest["delbydelid"] == geography_id]
+        data_points = ["d1", "d2"]
+        output = transform.df_to_template_i(geography_id, input_df, data_points, geography_name=geography_name)
+        self.assertEqual(output["id"], geography_id)
+        self.assertEqual(output["geography"], geography_name)
 
     def test_sub_district_time_series(self):
         sub_district = "0301010101"

--- a/tests/transform_output_test.py
+++ b/tests/transform_output_test.py
@@ -65,7 +65,9 @@ class Tester(unittest.TestCase):
         geography_name = "Subdistrict"
         input_df = test_df_latest[test_df_latest["delbydelid"] == geography_id]
         data_points = ["d1", "d2"]
-        output = transform.df_to_template_a(geography_id, input_df, data_points, geography_name=geography_name)
+        output = transform.df_to_template_a(
+            geography_id, input_df, data_points, geography_name=geography_name
+        )
         self.assertEqual(output["id"], geography_id)
         self.assertEqual(output["geography"], geography_name)
 
@@ -208,7 +210,11 @@ class Tester(unittest.TestCase):
         template = "c"
         data_points = ["d1", "d2"]
         output = transform.sub_district_time_series(
-            test_df, sub_district_id, template, data_points, sub_district_name=sub_district_name
+            test_df,
+            sub_district_id,
+            template,
+            data_points,
+            sub_district_name=sub_district_name,
         )
         self.assertEqual(output["id"], sub_district_id)
         self.assertEqual(output["geography"], sub_district_name)

--- a/tests/transform_output_test.py
+++ b/tests/transform_output_test.py
@@ -60,6 +60,15 @@ class Tester(unittest.TestCase):
         }
         self.assertDictEqual(output, expected)
 
+    def test_df_to_template_a_with_geography_name(self):
+        geography_id = "0301010101"
+        geography_name = "Subdistrict"
+        input_df = test_df_latest[test_df_latest["delbydelid"] == geography_id]
+        data_points = ["d1", "d2"]
+        output = transform.df_to_template_a(geography_id, input_df, data_points, geography_name=geography_name)
+        self.assertEqual(output["id"], geography_id)
+        self.assertEqual(output["geography"], geography_name)
+
     def test_df_to_template_b(self):
         geography = "0301010101"
         input_df = test_df[test_df["delbydelid"] == geography]
@@ -193,6 +202,17 @@ class Tester(unittest.TestCase):
         }
         self.assertDictEqual(output, expected)
 
+    def test_sub_district_time_series(self):
+        sub_district_id = "0301010101"
+        sub_district_name = "Subdistrict"
+        template = "c"
+        data_points = ["d1", "d2"]
+        output = transform.sub_district_time_series(
+            test_df, sub_district_id, template, data_points, sub_district_name=sub_district_name
+        )
+        self.assertEqual(output["id"], sub_district_id)
+        self.assertEqual(output["geography"], sub_district_name)
+
     def test_district_time_series(self):
         district = "01"
         template = "c"
@@ -217,6 +237,17 @@ class Tester(unittest.TestCase):
         }
         self.assertDictEqual(output, expected)
 
+    def test_district_time_series_with_geography_name(self):
+        district_id = "01"
+        district_name = "District"
+        template = "c"
+        data_points = ["d1", "d2"]
+        output = transform.district_time_series(
+            test_df, district_id, template, data_points, district_name=district_name
+        )
+        self.assertEqual(output["id"], district_id)
+        self.assertEqual(output["geography"], district_name)
+
     def test_district_time_series_list(self):
         district = "01"
         template = "a"
@@ -226,6 +257,20 @@ class Tester(unittest.TestCase):
         )
         expected = test_data.district_01_time_series_list
         self.assertListEqual(output, expected)
+
+    def test_district_time_series_list_with_geography_name(self):
+        district_id = "01"
+        district_name = "01"
+        template = "a"
+        data_points = ["d1", "d2"]
+        output = transform.district_time_series_list(
+            test_df, district_id, template, data_points, district_name=district_name
+        )
+        expected = test_data.district_01_time_series_list
+        self.assertEqual(output[0]["id"], "00")
+        self.assertEqual(output[0]["geography"], "Oslo i alt")
+        self.assertEqual(output[1]["id"], district_id)
+        self.assertEqual(output[1]["geography"], district_name)
 
     def test_generate_output_list(self):
         template = "c"

--- a/tests/transform_output_test.py
+++ b/tests/transform_output_test.py
@@ -92,7 +92,9 @@ class Tester(unittest.TestCase):
         geography_name = "Subdistrict"
         input_df = test_df[test_df["delbydelid"] == geography_id]
         data_points = ["d1"]
-        output = transform.df_to_template_b(geography_id, input_df, data_points, geography_name=geography_name)
+        output = transform.df_to_template_b(
+            geography_id, input_df, data_points, geography_name=geography_name
+        )
         self.assertEqual(output["id"], geography_id)
         self.assertEqual(output["geography"], geography_name)
 
@@ -146,7 +148,9 @@ class Tester(unittest.TestCase):
         geography_name = "Subdistrict"
         input_df = test_df[test_df["delbydelid"] == geography_id]
         data_points = ["d1", "d2"]
-        output = transform.df_to_template_c(geography_id, input_df, data_points, geography_name=geography_name)
+        output = transform.df_to_template_c(
+            geography_id, input_df, data_points, geography_name=geography_name
+        )
         self.assertEqual(output["id"], geography_id)
         self.assertEqual(output["geography"], geography_name)
 
@@ -171,7 +175,9 @@ class Tester(unittest.TestCase):
         geography_name = "Subdistrict"
         input_df = test_df_latest[test_df_latest["delbydelid"] == geography_id]
         data_points = ["d1", "d2"]
-        output = transform.df_to_template_i(geography_id, input_df, data_points, geography_name=geography_name)
+        output = transform.df_to_template_i(
+            geography_id, input_df, data_points, geography_name=geography_name
+        )
         self.assertEqual(output["id"], geography_id)
         self.assertEqual(output["geography"], geography_name)
 
@@ -196,7 +202,9 @@ class Tester(unittest.TestCase):
         geography_name = "0301010101"
         input_df = test_df_latest[test_df_latest["delbydelid"] == geography_id]
         data_points = ["d1", "d2"]
-        output = transform.df_to_template_i(geography_id, input_df, data_points, geography_name=geography_name)
+        output = transform.df_to_template_i(
+            geography_id, input_df, data_points, geography_name=geography_name
+        )
         self.assertEqual(output["id"], geography_id)
         self.assertEqual(output["geography"], geography_name)
 

--- a/tests/transform_output_test.py
+++ b/tests/transform_output_test.py
@@ -170,7 +170,7 @@ class Tester(unittest.TestCase):
         }
         self.assertDictEqual(output, expected)
 
-    def test_df_to_template_i(self):
+    def test_df_to_template_i_with_geography_name(self):
         geography_id = "0301010101"
         geography_name = "Subdistrict"
         input_df = test_df_latest[test_df_latest["delbydelid"] == geography_id]


### PR DESCRIPTION
This allows user to pass in 'bydel_navn' and 'delbydel_navn' columns and use these as values in the 'geography' field.

The 'delbydel' and 'district' columns will then instead be used to populate a new 'id' field.

Code changes are in the first commit, formatting changes in the second.