### PR TITLE
Fix folkemengde crash on unexpected columns

### DIFF
--- a/functions/folkemengde.py
+++ b/functions/folkemengde.py
@@ -54,6 +54,7 @@ def filter_10year_set(df):
 
 
 def calculate_change(df, *, column_name):
+    df = df[["bydel_id", "delbydel_id", "date", "population"]]
     indexed = df.set_index(["bydel_id", "delbydel_id", "date"])
     grouped = indexed.groupby(level="delbydel_id")
     return grouped.diff().rename(columns={"population": column_name}).reset_index()

--- a/tests/test_functions_folkemengde.py
+++ b/tests/test_functions_folkemengde.py
@@ -40,6 +40,22 @@ class TestFilter10YearSet:
 
 
 class TestCalculateChange:
+    def test_columns_are_dropped(self):
+        df = pd.DataFrame(
+            data={
+                "date": [2009, 2010],
+                "population": [100, 105],
+                "bydel_id": "01",
+                "delbydel_id": "0101",
+                "bydel_navn": "Fydel",
+                "delbydel_navn": "Delfydel",
+            }
+        )
+        try:
+            df = calculate_change(df, column_name="change")
+        except Exception:
+            pytest.fail("bydel_navn and delbydel_navn columns were not dropped")
+
     def test_change(self):
         df = pd.DataFrame(
             data={


### PR DESCRIPTION
If unexpected columns are present when calculating diffs for population
pandas may crash.